### PR TITLE
fix: Add ESLint v9 config for GitHub Actions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,22 @@
+export default [
+  {
+    files: ['src/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: {
+        console: 'readonly',
+        process: 'readonly',
+        Buffer: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+      },
+    },
+    rules: {
+      'no-unused-vars': 'warn',
+      'no-console': 'off',
+      'semi': ['error', 'always'],
+      'quotes': ['error', 'single'],
+    },
+  },
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,9 +7,6 @@ export default [
       globals: {
         console: 'readonly',
         process: 'readonly',
-        Buffer: 'readonly',
-        __dirname: 'readonly',
-        __filename: 'readonly',
       },
     },
     rules: {


### PR DESCRIPTION
Fixes the GitHub Packages publishing workflow by adding the required ESLint v9 configuration file.

ESLint v9 now requires eslint.config.js instead of .eslintrc.json

This should fix the failing GitHub Packages publish workflow.