### PR TITLE
fix: Dynamic version loading for CLI consistency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,11 @@ const execAsync = promisify(exec);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Read version from package.json
+const packageJsonPath = path.join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const VERSION = packageJson.version;
+
 const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
 
 // ASCII Art Banner
@@ -28,7 +33,7 @@ const banner = chalk.cyan(`
 `);
 
 program
-  .version('1.1.0')
+  .version(VERSION)
   .description(
     '🧙‍♂️ StackWizard - Magical full-stack project generator with FastAPI, React, and PostgreSQL'
   )


### PR DESCRIPTION
## Problem
CLI was showing version **1.1.0** while package.json and NPM package have version **1.0.0**.

## Solution
- Replace hardcoded version string with dynamic loading from package.json
- Read version at runtime using `fs.readFileSync`
- Ensures CLI version always matches package version

## Testing
1.0.0

## Benefits
- Eliminates version inconsistencies
- Single source of truth for version
- No more manual version updates in multiple places