### PR TITLE
fix: Docker npm dependency installation improvements

### DIFF
--- a/templates/frontend-mui/Dockerfile
+++ b/templates/frontend-mui/Dockerfile
@@ -2,9 +2,13 @@ FROM node:18-alpine
 
 WORKDIR /app
 
+# Copy package files
 COPY package*.json ./
-RUN npm install
 
+# Install dependencies with clean install to ensure lock file is respected
+RUN npm ci || npm install
+
+# Copy application files
 COPY . .
 
 EXPOSE 3000

--- a/templates/frontend-tailwind/Dockerfile
+++ b/templates/frontend-tailwind/Dockerfile
@@ -2,9 +2,13 @@ FROM node:18-alpine
 
 WORKDIR /app
 
+# Copy package files
 COPY package*.json ./
-RUN npm install
 
+# Install dependencies with clean install to ensure lock file is respected
+RUN npm ci || npm install
+
+# Copy application files
 COPY . .
 
 EXPOSE 3000


### PR DESCRIPTION
## Problem
Users were experiencing 'Module not found' errors for @headlessui/react and @heroicons/react when running Tailwind template in Docker containers.

## Solution
Improved npm dependency installation in Docker by:
- Using `npm ci` for faster, more reliable installs when package-lock.json exists
- Falls back to `npm install` if ci fails
- Ensures all dependencies from package-lock.json are properly installed

## Changes
- Updated Dockerfile for both Tailwind and MUI templates
- Added comments for clarity
- Using `npm ci` ensures exact versions from lock file are installed

## Testing
- Tested with fresh project generation
- Verified dependencies are correctly installed in containers
- Both MUI and Tailwind templates work correctly

Fixes the issue reported by user where Tailwind dependencies were missing in Docker container.